### PR TITLE
Fix refresh to only update single digits

### DIFF
--- a/include/CanDataHandler.h
+++ b/include/CanDataHandler.h
@@ -44,12 +44,8 @@ public:
 
   static void initCan(int canBaud);
   static void canMShandler(const CAN_message_t& msg);
-  static void setNewData(bool newData);
-  static bool getNewData();
 
 private:
-  static bool _newData;
-
   static MegaCAN _mega_can;
   static MegaCAN_broadcast_message_t _bCastMsg;
 };

--- a/include/DisplayHandler.h
+++ b/include/DisplayHandler.h
@@ -9,8 +9,6 @@
 #include <utility>
 #include <vector>
 
-const int kMaxDigits = 5;
-
 enum FontSize : int
 {
   kFontSizeSmall = 1,  // Font size 6x8
@@ -64,6 +62,10 @@ private:
   int _gaugeCursorIndex;
 
   void _refreshData(int dataIndex, FontSize fontSize, int cursorX, int cursorY);
+  void _drawData(int dataIndex, FontSize fontSize, int cursorX, int cursorY);
+  void _drawLabel(int dataIndex, FontSize fontSize, int cursorX, int cursorY);
+  void _highlightLabel(int dataIndex, FontSize fontSize, int cursorX, int cursorY, uint16_t textColor,
+                       uint16_t backgroundColor);
   int _getFontWidth(FontSize fontSize) const;
   int _getFontHeight(FontSize fontSize) const;
   int _getCenterOffset(FontSize fontSize, int length) const;
@@ -71,13 +73,13 @@ private:
   void _displayDashboard();
   void _refreshDashboard();
 
-  void _displayQuad();
+  void _drawQuad();
   void _refreshQuad();
 
-  void _displayDual();
+  void _drawDual();
   void _refreshDual();
 
-  void _displaySingle();
+  void _drawSingle();
   void _refreshSingle();
 
   void _highlightQuadGauge(uint16_t textColor, uint16_t backgroundColor);

--- a/include/DisplayHandler.h
+++ b/include/DisplayHandler.h
@@ -9,24 +9,6 @@
 #include <utility>
 #include <vector>
 
-const int kFontWidthSmall = 6;
-const int kFontHeightSmall = 8;
-
-const int kFontWidthMedium = 12;
-const int kFontHeightMedium = 16;
-
-const int kFontWidthLarge = 18;
-const int kFontHeightLarge = 24;
-
-const int kFontWidthXL = 24;
-const int kFontHeightXL = 36;
-
-const int kFontWidthXXL = 30;
-const int kFontHeightXXL = 44;
-
-const int kFontWidthXXXL = 36;
-const int kFontHeightXXXL = 52;
-
 const int kMaxDigits = 5;
 
 enum FontSize : int
@@ -81,6 +63,11 @@ private:
   bool _dataUpdated;
   int _gaugeCursorIndex;
 
+  void _refreshData(int dataIndex, FontSize fontSize, int cursorX, int cursorY);
+  int _getFontWidth(FontSize fontSize) const;
+  int _getFontHeight(FontSize fontSize) const;
+  int _getCenterOffset(FontSize fontSize, int length) const;
+
   void _displayDashboard();
   void _refreshDashboard();
 
@@ -96,6 +83,4 @@ private:
   void _highlightQuadGauge(uint16_t textColor, uint16_t backgroundColor);
   void _highlightDualGauge(uint16_t textColor, uint16_t backgroundColor);
   void _highlightSingleGauge(uint16_t textColor, uint16_t backgroundColor);
-
-  int _getCenterOffset(FontSize fontSize, int length) const;
 };

--- a/src/CanDataHandler.cpp
+++ b/src/CanDataHandler.cpp
@@ -1,5 +1,6 @@
 #include "CanDataHandler.h"
 
+#include <Chrono.h>
 #include <FlexCAN_T4.h>
 
 FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_16> can;
@@ -7,8 +8,6 @@ FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_16> can;
 constexpr uint32_t kBaseID = 1520; // This is set in megasquirt (typically 1520)
 
 MegaCAN_broadcast_message_t CanDataHandler::_bCastMsg = {};
-
-bool CanDataHandler::_newData = false;
 MegaCAN CanDataHandler::_mega_can(kBaseID);
 
 void CanDataHandler::initCan(int canBaud)
@@ -57,8 +56,6 @@ std::vector<std::pair<GaugeData, String>> CanDataHandler::getGaugeData(const std
       break;
     };
   }
-  // Data is no longer new, so we need to reset the flag.
-  _newData = false;
 
   return data;
 }
@@ -70,16 +67,5 @@ void CanDataHandler::canMShandler(const CAN_message_t& msg)
   {
     // broadcast data from MS does not use extended flag, therefore this should be broadcast data from MS
     _mega_can.getBCastData(msg.id, msg.buf, _bCastMsg);
-    _newData = true;
   }
-}
-
-void CanDataHandler::setNewData(bool newData)
-{
-  _newData = newData;
-}
-
-bool CanDataHandler::getNewData()
-{
-  return _newData;
 }

--- a/src/CanDataHandler.cpp
+++ b/src/CanDataHandler.cpp
@@ -1,6 +1,5 @@
 #include "CanDataHandler.h"
 
-#include <Chrono.h>
 #include <FlexCAN_T4.h>
 
 FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_16> can;

--- a/src/DisplayHandler.cpp
+++ b/src/DisplayHandler.cpp
@@ -32,13 +32,13 @@ void DisplayHandler::display()
       _displayDashboard();
     break;
   case kQuadGauge:
-    _gaugeViewUpdated ? _displayQuad() : _refreshQuad();
+    _gaugeViewUpdated ? _drawQuad() : _refreshQuad();
     break;
   case kDualGauge:
-    _gaugeViewUpdated ? _displayDual() : _refreshDual();
+    _gaugeViewUpdated ? _drawDual() : _refreshDual();
     break;
   case kSingleGauge:
-    _gaugeViewUpdated ? _displaySingle() : _refreshSingle();
+    _gaugeViewUpdated ? _drawSingle() : _refreshSingle();
     break;
   default:
     Serial.print(_currentGaugeView);
@@ -153,6 +153,41 @@ void DisplayHandler::_refreshData(int dataIndex, FontSize fontSize, int cursorX,
   }
 }
 
+// Draws the data given the data center X coordinate and top Y coordinate.
+void DisplayHandler::_drawData(int dataIndex, FontSize fontSize, int cursorX, int cursorY)
+{
+  _tft.setTextSize(fontSize);
+  _tft.setTextColor(WHITE);
+
+  _tft.setCursor(cursorX - _getCenterOffset(fontSize, _currentData[dataIndex].second.length()), cursorY);
+  _tft.println(_currentData[dataIndex].second);
+}
+
+// Draws the label given the data center X coordinate and top Y coordinate.
+void DisplayHandler::_drawLabel(int dataIndex, FontSize fontSize, int cursorX, int cursorY)
+{
+  _tft.setTextSize(fontSize);
+  _tft.setTextColor(WHITE);
+
+  _tft.setCursor(cursorX - _getCenterOffset(fontSize, GaugeLabels[_currentData[dataIndex].first].length()), cursorY);
+  _tft.println(GaugeLabels[_currentData[dataIndex].first]);
+}
+
+// Highlights the label given the data center X coordinate and top Y coordinate.
+void DisplayHandler::_highlightLabel(int dataIndex, FontSize fontSize, int cursorX, int cursorY, uint16_t textColor,
+                                     uint16_t backgroundColor)
+{
+  _tft.setTextSize(fontSize);
+  _tft.setTextColor(textColor);
+
+  _tft.fillRect(cursorX - _getCenterOffset(fontSize, GaugeLabels[_currentData[dataIndex].first].length()) - 1,
+                cursorY - 1, _getFontWidth(kFontSizeMedium) * GaugeLabels[_currentData[dataIndex].first].length(),
+                _getFontHeight(kFontSizeMedium), backgroundColor);
+  _tft.setCursor(cursorX - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[dataIndex].first].length()),
+                 cursorY);
+  _tft.println(GaugeLabels[_currentData[dataIndex].first]);
+}
+
 // Returns the width in pixels of a given font size
 int DisplayHandler::_getFontWidth(FontSize fontSize) const
 {
@@ -185,61 +220,27 @@ void DisplayHandler::_displayDashboard()
   _tft.println("Dashboard goes here!");
 }
 
-// Displays 4 gauges divided into 4 quadrants.
-// Labels 10 characters and data 5 characters max.
-void DisplayHandler::_displayQuad()
+void DisplayHandler::_drawQuad()
 {
   clearScreen();
 
   _tft.drawFastHLine(0, _screenHeight / 2, _screenWidth, WHITE);
   _tft.drawFastVLine(_screenWidth / 2, 0, _screenHeight, WHITE);
 
-  _tft.setTextSize(kFontSizeMedium);
-  _tft.setTextColor(WHITE);
-
   if (_currentData.size() < 4)
   {
     Serial.println("Current data has less than 4 gauges!");
   }
 
-  // Print labels
-  _tft.setCursor((_screenWidth / 4) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[0].first].length()),
-                 (_screenHeight / 2) - 20);
-  _tft.println(GaugeLabels[_currentData[0].first]);
+  _drawLabel(0, kFontSizeMedium, _screenWidth / 4, (_screenHeight / 2) - 20);
+  _drawLabel(1, kFontSizeMedium, _screenWidth - (_screenWidth / 4), (_screenHeight / 2) - 20);
+  _drawLabel(2, kFontSizeMedium, _screenWidth / 4, (_screenHeight / 2) + 6);
+  _drawLabel(3, kFontSizeMedium, _screenWidth - (_screenWidth / 4), (_screenHeight / 2) + 6);
 
-  _tft.setCursor(_screenWidth - (_screenWidth / 4) -
-                     _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[1].first].length()),
-                 (_screenHeight / 2) - 20);
-  _tft.println(GaugeLabels[_currentData[1].first]);
-
-  _tft.setCursor((_screenWidth / 4) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[2].first].length()),
-                 (_screenHeight / 2) + 6);
-  _tft.println(GaugeLabels[_currentData[2].first]);
-
-  _tft.setCursor(_screenWidth - (_screenWidth / 4) -
-                     _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[3].first].length()),
-                 (_screenHeight / 2) + 6);
-  _tft.println(GaugeLabels[_currentData[3].first]);
-
-  // Print data
-  _tft.setTextSize(kFontSizeLarge);
-  _tft.setTextColor(WHITE);
-
-  _tft.setCursor((_screenWidth / 4) - _getCenterOffset(kFontSizeLarge, _currentData[0].second.length()),
-                 (_screenHeight / 2) - 50);
-  _tft.println(_currentData[0].second);
-
-  _tft.setCursor(_screenWidth - (_screenWidth / 4) - _getCenterOffset(kFontSizeLarge, _currentData[1].second.length()),
-                 (_screenHeight / 2) - 50);
-  _tft.println(_currentData[1].second);
-
-  _tft.setCursor((_screenWidth / 4) - _getCenterOffset(kFontSizeLarge, _currentData[2].second.length()),
-                 (_screenHeight / 2) + 30);
-  _tft.println(_currentData[2].second);
-
-  _tft.setCursor(_screenWidth - (_screenWidth / 4) - _getCenterOffset(kFontSizeLarge, _currentData[3].second.length()),
-                 (_screenHeight / 2) + 30);
-  _tft.println(_currentData[3].second);
+  _drawData(0, kFontSizeLarge, _screenWidth / 4, (_screenHeight / 2) - 50);
+  _drawData(1, kFontSizeLarge, _screenWidth - (_screenWidth / 4), (_screenHeight / 2) - 50);
+  _drawData(2, kFontSizeLarge, _screenWidth / 4, (_screenHeight / 2) + 30);
+  _drawData(3, kFontSizeLarge, _screenWidth - (_screenWidth / 4), (_screenHeight / 2) + 30);
 }
 
 // Refreshes changed data on the 4 gauge view.
@@ -266,40 +267,22 @@ void DisplayHandler::_refreshQuad()
   }
 }
 
-void DisplayHandler::_displayDual()
+void DisplayHandler::_drawDual()
 {
   clearScreen();
 
   _tft.drawFastHLine(0, _screenHeight / 2, _screenWidth, WHITE);
-
-  _tft.setTextSize(kFontSizeMedium);
-  _tft.setTextColor(WHITE);
 
   if (_currentData.size() < 2)
   {
     Serial.println("Current data has less than 2 gauges!");
   }
 
-  // Print labels
-  _tft.setCursor((_screenWidth / 2) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[0].first].length()),
-                 (_screenHeight / 2) - _getFontHeight(kFontSizeMedium) - 4);
-  _tft.println(GaugeLabels[_currentData[0].first]);
+  _drawLabel(0, kFontSizeMedium, _screenWidth / 2, (_screenHeight / 2) - 20);
+  _drawLabel(1, kFontSizeMedium, _screenWidth / 2, (_screenHeight / 2) + 6);
 
-  _tft.setCursor((_screenWidth / 2) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[1].first].length()),
-                 (_screenHeight / 2) + 6);
-  _tft.println(GaugeLabels[_currentData[1].first]);
-
-  // Print data
-  _tft.setTextSize(kFontSizeXL);
-  _tft.setTextColor(WHITE);
-
-  _tft.setCursor((_screenWidth / 2) - _getCenterOffset(kFontSizeXL, _currentData[0].second.length()),
-                 (_screenHeight / 2) - 75);
-  _tft.println(_currentData[0].second);
-
-  _tft.setCursor((_screenWidth / 2) - _getCenterOffset(kFontSizeXL, _currentData[1].second.length()),
-                 (_screenHeight / 2) + 55);
-  _tft.println(_currentData[1].second);
+  _drawData(0, kFontSizeXL, _screenWidth / 2, (_screenHeight / 2) - 75);
+  _drawData(1, kFontSizeXL, _screenWidth / 2, (_screenHeight / 2) + 55);
 }
 
 // Refreshes changed data on the 2 gauge view.
@@ -318,7 +301,7 @@ void DisplayHandler::_refreshDual()
   }
 }
 
-void DisplayHandler::_displaySingle()
+void DisplayHandler::_drawSingle()
 {
   clearScreen();
 
@@ -327,21 +310,9 @@ void DisplayHandler::_displaySingle()
     Serial.println("Current data has less than 1 gauge!");
   }
 
-  // Print label
-  _tft.setTextSize(kFontSizeLarge);
-  _tft.setTextColor(WHITE);
+  _drawLabel(0, kFontSizeLarge, _screenWidth / 2, (_screenHeight / 2) + 55);
 
-  _tft.setCursor((_screenWidth / 2) - _getCenterOffset(kFontSizeLarge, GaugeLabels[_currentData[0].first].length()),
-                 (_screenHeight / 2) + 55);
-  _tft.println(GaugeLabels[_currentData[0].first]);
-
-  // Print data
-  _tft.setTextSize(kFontSizeXXXL);
-  _tft.setTextColor(WHITE);
-
-  _tft.setCursor((_screenWidth / 2) - _getCenterOffset(kFontSizeXXXL, _currentData[0].second.length()),
-                 (_screenHeight / 2) - 70);
-  _tft.println(_currentData[0].second);
+  _drawData(0, kFontSizeXXXL, _screenWidth / 2, (_screenHeight / 2) - 70);
 }
 
 // Refreshes changed data on the 1 gauge view.
@@ -359,49 +330,23 @@ void DisplayHandler::_refreshSingle()
 // Highlights a gauge to be used as a cursor. Invert can be set to move the cursor.
 void DisplayHandler::_highlightQuadGauge(uint16_t textColor, uint16_t backgroundColor)
 {
-  _tft.setTextColor(textColor);
-  _tft.setTextSize(kFontSizeMedium);
   switch (_gaugeCursorIndex)
   {
   case 0:
-    _tft.fillRect(
-        (_screenWidth / 4) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[0].first].length()) - 1,
-        (_screenHeight / 2) - 20 - 1, _getFontWidth(kFontSizeMedium) * GaugeLabels[_currentData[0].first].length(),
-        _getFontHeight(kFontSizeMedium), backgroundColor);
-    _tft.setCursor((_screenWidth / 4) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[0].first].length()),
-                   (_screenHeight / 2) - 20);
-    _tft.println(GaugeLabels[_currentData[0].first]);
+    _highlightLabel(_gaugeCursorIndex, kFontSizeMedium, _screenWidth / 4, (_screenHeight / 2) - 20, textColor,
+                    backgroundColor);
     break;
   case 1:
-    _tft.fillRect(_screenWidth - (_screenWidth / 4) -
-                      _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[1].first].length()) - 1,
-                  (_screenHeight / 2) - 20 - 1,
-                  _getFontWidth(kFontSizeMedium) * GaugeLabels[_currentData[1].first].length(),
-                  _getFontHeight(kFontSizeMedium), backgroundColor);
-    _tft.setCursor(_screenWidth - (_screenWidth / 4) -
-                       _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[1].first].length()),
-                   (_screenHeight / 2) - 20);
-    _tft.println(GaugeLabels[_currentData[1].first]);
+    _highlightLabel(_gaugeCursorIndex, kFontSizeMedium, _screenWidth - (_screenWidth / 4), (_screenHeight / 2) - 20,
+                    textColor, backgroundColor);
     break;
   case 2:
-    _tft.fillRect(
-        (_screenWidth / 4) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[2].first].length()) - 1,
-        (_screenHeight / 2) + 6 - 1, _getFontWidth(kFontSizeMedium) * GaugeLabels[_currentData[2].first].length(),
-        _getFontHeight(kFontSizeMedium), backgroundColor);
-    _tft.setCursor((_screenWidth / 4) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[2].first].length()),
-                   (_screenHeight / 2) + 6);
-    _tft.println(GaugeLabels[_currentData[2].first]);
+    _highlightLabel(_gaugeCursorIndex, kFontSizeMedium, _screenWidth / 4, (_screenHeight / 2) + 6, textColor,
+                    backgroundColor);
     break;
   case 3:
-    _tft.fillRect(_screenWidth - (_screenWidth / 4) -
-                      _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[3].first].length()) - 1,
-                  (_screenHeight / 2) + 6 - 1,
-                  _getFontWidth(kFontSizeMedium) * GaugeLabels[_currentData[3].first].length(),
-                  _getFontHeight(kFontSizeMedium), backgroundColor);
-    _tft.setCursor(_screenWidth - (_screenWidth / 4) -
-                       _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[3].first].length()),
-                   (_screenHeight / 2) + 6);
-    _tft.println(GaugeLabels[_currentData[3].first]);
+    _highlightLabel(_gaugeCursorIndex, kFontSizeMedium, _screenWidth - (_screenWidth / 4), (_screenHeight / 2) + 6,
+                    textColor, backgroundColor);
     break;
   }
 }
@@ -409,27 +354,15 @@ void DisplayHandler::_highlightQuadGauge(uint16_t textColor, uint16_t background
 // Highlights a gauge to be used as a cursor. Invert can be set to move the cursor.
 void DisplayHandler::_highlightDualGauge(uint16_t textColor, uint16_t backgroundColor)
 {
-  _tft.setTextColor(textColor);
-  _tft.setTextSize(kFontSizeMedium);
   switch (_gaugeCursorIndex)
   {
   case 0:
-    _tft.fillRect(
-        (_screenWidth / 2) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[0].first].length()) - 1,
-        (_screenHeight / 2) - 20 - 1, _getFontWidth(kFontSizeMedium) * GaugeLabels[_currentData[0].first].length(),
-        _getFontHeight(kFontSizeMedium), backgroundColor);
-    _tft.setCursor((_screenWidth / 2) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[0].first].length()),
-                   (_screenHeight / 2) - 20);
-    _tft.println(GaugeLabels[_currentData[0].first]);
+    _highlightLabel(_gaugeCursorIndex, kFontSizeMedium, _screenWidth / 2, (_screenHeight / 2) - 20, textColor,
+                    backgroundColor);
     break;
   case 1:
-    _tft.fillRect(
-        (_screenWidth / 2) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[1].first].length()) - 1,
-        (_screenHeight / 2) + 6 - 1, _getFontWidth(kFontSizeMedium) * GaugeLabels[_currentData[1].first].length(),
-        _getFontHeight(kFontSizeMedium), backgroundColor);
-    _tft.setCursor((_screenWidth / 2) - _getCenterOffset(kFontSizeMedium, GaugeLabels[_currentData[1].first].length()),
-                   (_screenHeight / 2) + 6);
-    _tft.println(GaugeLabels[_currentData[1].first]);
+    _highlightLabel(_gaugeCursorIndex, kFontSizeMedium, _screenWidth / 2, (_screenHeight / 2) + 6, textColor,
+                    backgroundColor);
     break;
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "StateManager.h"
 
 #include <Arduino.h>
+#include <Chrono.h>
 #include <utility>
 #include <vector>
 
@@ -22,14 +23,17 @@
 #define SCREEN_WIDTH 240
 #define SCREEEN_HEIGHT 240
 
-const int kCanBaud = 500000;       // Baud rate of the CAN bus
-const int kDoubleClickSpeed = 300; // Max time between clicks for double click in ms
+const int kCanBaud = 500000;           // Baud rate of the CAN bus
+const int kDoubleClickSpeed = 300;     // Max time between clicks for double click in ms
+const int kDisplayRefreshPeriod = 100; // Time between refresh in ms
 
 CanDataHandler canDataHandler;
 DisplayHandler displayHandler(TFT_RST, TFT_DC, TFT_CS, SCREEEN_HEIGHT, SCREEN_WIDTH);
 EncoderHandler encoderHandler(ENC_1, ENC_2, ENC_B, kDoubleClickSpeed);
 
 StateManager stateManager(encoderHandler, canDataHandler, displayHandler);
+
+Chrono displayRefreshTimer;
 
 void setup()
 {
@@ -47,8 +51,9 @@ void loop()
 {
   stateManager.poll();
 
-  if (canDataHandler.getNewData() || DEBUG)
+  if (displayRefreshTimer.hasPassed(kDisplayRefreshPeriod))
   {
     stateManager.serveData();
+    displayRefreshTimer.restart();
   }
 }


### PR DESCRIPTION
Refreshing the entire data can cause digits that aren't changing to flicker. Updating to only update changed digits.